### PR TITLE
include protocol in socket address

### DIFF
--- a/App/socket.ts
+++ b/App/socket.ts
@@ -2,7 +2,7 @@
 import io from "socket.io-client";
 import { IAppConfig, ITileState } from "./TileConfig";
 
-export const SOCKET_URL = `http://${globalThis.location?.hostname || "0.0.0.0"}`;
+export const SOCKET_URL = `${globalThis.location?.origin || "http://0.0.0.0"}`;
 export const SOCKET_PORT = 7273;
 let socket: ReturnType<typeof io>;
 export const getSocket = () => socket || (socket = io(`${SOCKET_URL}:${SOCKET_PORT}`));


### PR DESCRIPTION
if you access the site via an https proxy/lb Chrome fails to open the socket because of mixed-content restrictions