### PR TITLE
fix SOCKET_URL assignment, do not include port

### DIFF
--- a/App/socket.ts
+++ b/App/socket.ts
@@ -2,7 +2,7 @@
 import io from "socket.io-client";
 import { IAppConfig, ITileState } from "./TileConfig";
 
-export const SOCKET_URL = `${globalThis.location?.origin || "http://0.0.0.0"}`;
+export const SOCKET_URL = `${globalThis.location?.protocol || "http"}//${globalThis.location?.hostname || "0.0.0.0"}`;
 export const SOCKET_PORT = 7273;
 let socket: ReturnType<typeof io>;
 export const getSocket = () => socket || (socket = io(`${SOCKET_URL}:${SOCKET_PORT}`));


### PR DESCRIPTION
location.origin was inadvertently adding the (wrong) port to the URL